### PR TITLE
Remove trailing newline from generated help

### DIFF
--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -232,6 +232,8 @@ proc genHelp(builder: Builder):string {.compileTime.} =
     result.add(opts)
     result.add("\L")
 
+  result.stripLineEnd
+
 proc genHelpProc(builder: Builder): NimNode {.compileTime.} =
   let ParserIdent = builder.parserIdent()
   let helptext = builder.genHelp()


### PR DESCRIPTION
A more predictable behavior.