### PR TITLE
fix implicit conversion to proc

### DIFF
--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -928,8 +928,7 @@ template newParser*(name: string, content: untyped): untyped =
     assert p.parse(@["-a"]).a == true
 
   macro tmpmkParser(): untyped =
-    var res = mkParser(name):
-      content
+    var res = mkParser(name, proc() = content)
     newStmtList(
       res.types,
       res.body,


### PR DESCRIPTION
In this line of you, you rely on the feature that the expression is converted implicitly into a procedure. But this behavior in Nim is very flaky. For some expressions it does not work. 

https://github.com/nim-lang/Nim/issues/12110

This PR changes the code to use a proc expression that does not need implicit conversion anymore.


