### PR TITLE
Make command a template to avoid having to use the do: syntax

### DIFF
--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -905,6 +905,12 @@ template run*(content: untyped): untyped =
 
 proc add_command*(name: string, group: string, content: proc()) {.compileTime.} =
   ## INTERNAL
+  discard mkParser(name, false, group, content)
+
+template command*(name: string, group: string, content: untyped): untyped =
+  ## Add a sub-command to the argument parser.
+  ##
+  ## group is a string used to group commands in help output
   runnableExamples:
     var p = newParser("Some Program"):
       command("dostuff"):
@@ -912,12 +918,6 @@ proc add_command*(name: string, group: string, content: proc()) {.compileTime.} 
           echo "Actually do stuff"
     p.run(@["dostuff"])
 
-  discard mkParser(name, false, group, content)
-
-template command*(name: string, group: string, content: untyped): untyped =
-  ## Add a sub-command to the argument parser.
-  ##
-  ## group is a string used to group commands in help output
   add_command(name, group) do:
     content
 


### PR DESCRIPTION
An alternate solution to the the `do:` problem noted in #25 using a template to preserve terseness.

@krux02 Does this branch work with https://github.com/nim-lang/Nim/pull/12117 ?