### PR TITLE
Hidden options and flags

### DIFF
--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -793,6 +793,9 @@ proc flag*(opt1: string, opt2: string = "", multiple = false, help:string = "", 
   ##
   ## If ``multiple`` is true then the flag can be specified multiple
   ## times and the datatype will be an int.
+  ##
+  ## If ``hidden`` is true then the flag usage is not shown in the help.
+  ##
   runnableExamples:
     var p = newParser("Some Thing"):
       flag("-n", "--dryrun", help="Don't actually run")
@@ -828,6 +831,8 @@ proc option*(opt1: string, opt2: string = "", multiple = false, help:string="", 
   ## Set ``env`` to an environment variable name to use as the default value
   ## 
   ## Set ``choices`` to restrict the possible choices.
+  ##
+  ## Set ``hidden`` to exclude the flag usage from the help.
   ##
   runnableExamples:
     var p = newParser("Command"):

--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -832,7 +832,7 @@ proc option*(opt1: string, opt2: string = "", multiple = false, help:string="", 
   ## 
   ## Set ``choices`` to restrict the possible choices.
   ##
-  ## Set ``hidden`` to exclude the flag usage from the help.
+  ## Set ``hidden`` to prevent the option usage listing in the help text.
   ##
   runnableExamples:
     var p = newParser("Command"):

--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -949,8 +949,6 @@ template newParser*(name: string, content: untyped): untyped =
     assert p.parse(@["-a"]).a == true
 
   macro tmpmkParser(): untyped =
-    # Note: getEnv() works in the compile time but does not feetch the appname as $0 unlike bash
-    # when name.len < 2 or name[0] != '$': name else: getEnv(substr(name, 0), default="<" & substr(name, 0) & ">"),
     var res = mkParser(name, true, "", proc() = content)
     newStmtList(
       res.types,


### PR DESCRIPTION
Hidden options and flags are implemented (except for the positional arguments as expected), which is a standard feature in other argument parsers: `argparse.SUPPRESS` in Python `argparse`, `hidden` in [GNU Gengetopt](https://www.gnu.org/software/gengetopt/gengetopt.html). See also https://github.com/nim-lang/Nim/issues/12425#issuecomment-544808794 discussion about the `parseopt` replacement.