### PR TITLE
No longer export `macros` when importing `argparse`. Fixes #73

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
           - stable
           # - devel
           # no devel for now because GitHub Actions won't let me not fail for them
-          - 1.6.0
+          - 1.6.2
           - 1.4.8
-          - 1.2.8
+          - 1.2.16
           - 1.0.10
         os:
         - ubuntu-latest

--- a/changes/break-No-longer-export-20220131-162753.md
+++ b/changes/break-No-longer-export-20220131-162753.md
@@ -1,0 +1,1 @@
+No longer export `macros` when importing `argparse`. Fixes #73

--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -89,7 +89,7 @@ runnableExamples:
   assert opts.go.get.a == true
   assert opts.leave.isNone
 
-import macros; export macros
+import macros
 import strutils
 import argparse/backend; export backend
 import argparse/macrohelp; export macrohelp

--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -94,6 +94,9 @@ import strutils
 import argparse/backend; export backend
 import argparse/macrohelp; export macrohelp
 
+proc ident*(x: string): NimNode =
+  macros.ident(x)
+
 proc toVarname(x: string): string =
   ## Convert x to something suitable as a Nim identifier
   ## Replaces - with _ for instance

--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -94,8 +94,8 @@ import strutils
 import argparse/backend; export backend
 import argparse/macrohelp; export macrohelp
 
-proc ident*(x: string): NimNode =
-  macros.ident(x)
+template ident*(x: string): NimNode = macros.ident(x)
+template newIdentNode*(x: string): NimNode = macros.newIdentNode(x)
 
 proc toVarname(x: string): string =
   ## Convert x to something suitable as a Nim identifier

--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -89,13 +89,10 @@ runnableExamples:
   assert opts.go.get.a == true
   assert opts.leave.isNone
 
-import macros
+import std/macros
 import strutils
 import argparse/backend; export backend
 import argparse/macrohelp; export macrohelp
-
-template ident*(x: string): NimNode = macros.ident(x)
-template newIdentNode*(x: string): NimNode = macros.newIdentNode(x)
 
 proc toVarname(x: string): string =
   ## Convert x to something suitable as a Nim identifier

--- a/src/argparse/backend.nim
+++ b/src/argparse/backend.nim
@@ -217,8 +217,8 @@ proc propDefinitions(c: Component): seq[NimNode] =
       result.add identDef(
         ident(safeIdentStr(c.varname & "_opt")),
         nnkBracketExpr.newTree(
-          newIdentNode("Option"),
-          newIdentNode("string")
+          ident("Option"),
+          ident("string")
         )
       )
   of ArgArgument:

--- a/src/argparse/macrohelp.nim
+++ b/src/argparse/macrohelp.nim
@@ -21,6 +21,8 @@ type
     parent*: NimNode
     child*: NimNode
 
+const ident* = (proc(s: string): NimNode)(ident)
+const newIdentNode* = (proc(s: string): NimNode)(newIdentNode)
 
 proc replaceNodes*(ast: NimNode): NimNode =
   ## Replace NimIdent and NimSym by a fresh ident node

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -821,4 +821,4 @@ var p = newParser:
     checkpoint "=============== output =============="
     checkpoint output
     checkpoint "====================================="
-    check output == "ERROR ok\n"
+    check "ERROR ok" in output

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -802,3 +802,23 @@ echo p.parse().name
     checkpoint output
     checkpoint "====================================="
     check output == "bob\n"
+  
+  test "std/logging":
+    let tmpfile = currentSourcePath().parentDir() / "std_logging.nim"
+    defer:
+      removeFile(tmpfile)
+      removeFile(tmpfile.changeFileExt(ExeExt))
+    tmpfile.writeFile("""
+import std/logging, argparse
+addHandler newConsoleLogger()
+error "ok"
+var p = newParser:
+  arg("foo")
+    """)
+    let output = execProcess(findExe"nim",
+      args = ["c", "--hints:off", "--verbosity:0", "-r", tmpfile],
+      options = {poStdErrToStdOut})
+    checkpoint "=============== output =============="
+    checkpoint output
+    checkpoint "====================================="
+    check output == "ERROR ok\n"


### PR DESCRIPTION
I'm nervous about removing `export macros` because I thought it was necessary for the `templates` within argparse to have access to some macro code. Maybe that has changed since 1.0.x?