### PR TITLE
nit: change `do:` to `do ():` in command

### DIFF
--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -302,7 +302,7 @@ template command*(name: string, group: string, content: untyped): untyped =
       command("morestuff", "groupB"): discard
       command("morelikethefirst", "groupA"): discard
     echo p.help
-  add_command(name, group) do:
+  add_command(name, group) do ():
     content
 
 template command*(name: string, content: untyped): untyped =


### PR DESCRIPTION
This exploits a weird behavior in the compiler that is planned to be discouraged, see https://github.com/nim-lang/RFCs/issues/486. `do:` and `do ():` are supposed to mean different things, in this case `do ():` is meant.