### PR TITLE
Document setting option's default with a RT value

### DIFF
--- a/src/argparse.nim
+++ b/src/argparse.nim
@@ -191,6 +191,9 @@ proc option*(name1: string, name2 = "", help = "", default = none[string](), env
   ## Set ``multiple`` to true to accept multiple options.
   ##
   ## Set ``default`` to the default string value.
+  ## If the value can't be inferred at compile-time, insert it in the ``run``
+  ## block while accesing the option with
+  ## ``opts.FLAGNAME_opt.get(otherwise = RunTimeString)`` instead.
   ##
   ## Set ``env`` to an environment variable name to use as the default value
   ## 


### PR DESCRIPTION
...using `Option.get(otherwise)` func on `FLAGNAME_opt`

PS: current docs on GH pages are outdated, FLAGNAME_opt were added more than a year ago, docs are from 2021-10-25.