### PR TITLE
Short + long flag sort improvement

### DIFF
--- a/argparse.nimble
+++ b/argparse.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "4.0.2"
+version       = "4.1.2"
 author        = "Matt Haggard"
 description   = "A command line argument parser"
 license       = "MIT"
@@ -9,4 +9,4 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim >= 1.0.10"
+requires "nim >= 1.2.18" # tested through to 2.2.6 via choosenim

--- a/src/argparse/backend.nim
+++ b/src/argparse/backend.nim
@@ -79,6 +79,11 @@ type
     runProcs*: seq[proc()]
       ## Procs to be run at the end of parsing
 
+template doUsageAssert*(condition: bool, msg: string): untyped =
+  ## Raise a UsageError if condition is false
+  if not (`condition`):
+    raise UsageError.newException(`msg`)
+
 var ARGPARSE_STDOUT* = newFileStream(stdout)
 var builderStack* {.compileTime.} = newSeq[Builder]()
 


### PR DESCRIPTION
- Support just short or just long flag
- flag("-a") was previously written to Component.(optLong|flagLong) which is unexpected. A long form flag has the prefix "--" by convention.
- Document further/make explicit the forms of flags allowed

tested all versions from 1.2.18 with nimble test and choosenim

this MR paves the way for a following one i have which is generation of shell completions (ive only implemented fish but scaffolded so that others could implement bash, zsh etc)